### PR TITLE
Operator was being included in filter expression

### DIFF
--- a/__tests__/test.json
+++ b/__tests__/test.json
@@ -1,0 +1,8 @@
+{
+    "queryStringParameters": {
+        "Woreda_eq": "TOLL FREE"
+    },
+    "pathParameters": {
+        "type": "communities"
+    }
+}

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -71,17 +71,17 @@ module.exports.prepareFilterParams = queryStringParameters => {
     const operator = this.getFilterOperator(key.split('_')[1]);
 
     // Add ExpressionAttributeNames
-    ExpressionAttributeNames[`#${key}`] = `${field}`;
+    ExpressionAttributeNames[`#${field}`] = `${field}`;
 
     // ExpressionAttributeValues
-    ExpressionAttributeValues[`:${key}`] = queryValue;
+    ExpressionAttributeValues[`:${field}`] = queryValue;
 
     // FilterExpression
     if (FilterExpression) {
       FilterExpression =
-        `${FilterExpression} ` + 'AND' + ` #${key} ${operator} :${key}`;
+        `${FilterExpression} AND #${field} ${operator} :${field}`;
     } else {
-      FilterExpression = `#${key} ${operator} :${key}`;
+      FilterExpression = `#${field} ${operator} :${field}`;
     }
   }
 


### PR DESCRIPTION
Before:
```
{
  FilterExpression: '#Woreda**_eq** = :Woreda**_eq**',
  ExpressionAttributeNames: { '#Woreda**_eq**': 'Woreda' },
  ExpressionAttributeValues: { ':Woreda**_eq**': 'TOLL FREE' }
}
```


After:

```
{
  FilterExpression: '#Woreda = :Woreda_eq',
  ExpressionAttributeNames: { '#Woreda': 'Woreda' },
  ExpressionAttributeValues: { ':Woreda': 'TOLL FREE' }
}
```